### PR TITLE
1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `SingleFileDisasm`:
+  - Error out if the end address is larger than the start address of `.text` or
+    data.
+  - Avoid writing a `.text.s` file if the `.text` start and end addresses are
+    the same, as long as the user has given data addresses, otherwise panic.
+
 ### Fixed
 
 - Avoid guessing symbols as string if the first word of the symbol is an address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Context.setupGotTable()`: Allows finer control over the GOT table.
+  - The user can manually define which entries are got-local and which ones are
+    got-global, instead of relying on a given order.
+  - Useful for programs that don't follow the ABI way of defining the GOT; first
+    the locals entries and then the globals entries.
+- `common.GotEntry` class: Defines if an entry of the GOT is either local or
+  global. It must be used together with `Context.setupGotTable()`
+
 ### Changed
 
 - `SingleFileDisasm`:
@@ -14,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     data.
   - Avoid writing a `.text.s` file if the `.text` start and end addresses are
     the same, as long as the user has given data addresses, otherwise panic.
+
+### Deprecated
+
+- `Context.initGotTable()`: Prefer `Context.setupGotTable()` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid guessing symbols as string if the first word of the symbol is an address
+  to a known symbol.
+
 ## [1.36.1] - 2025-09-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `SingleFileDisasm`:
-  - Error out if the end address is larger than the start address of `.text` or
+  - Error out if the start address is larger than the end address of `.text` or
     data.
   - Avoid writing a `.text.s` file if the `.text` start and end addresses are
     the same, as long as the user has given data addresses, otherwise panic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.37.0] - 2025-09-18
+
 ### Added
 
 - `Context.setupGotTable()`: Allows finer control over the GOT table.
@@ -33,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Avoid guessing symbols as string if the first word of the symbol is an address
   to a known symbol.
+- `rabbitizer` 1.14.0 or above is required.
+  - Adds a new argument to the R3000GTE `dpct` instruction that exposes required
+    garbage bits.
 
 ## [1.36.1] - 2025-09-01
 
@@ -1915,6 +1920,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version 1.0.0
 
 [unreleased]: https://github.com/Decompollaborate/spimdisasm/compare/master...develop
+[1.37.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.36.1...1.37.0
 [1.36.1]: https://github.com/Decompollaborate/spimdisasm/compare/1.36.0...1.36.1
 [1.36.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.35.0...1.36.0
 [1.35.0]: https://github.com/Decompollaborate/spimdisasm/compare/1.34.2...1.35.0

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use a `requirements.txt` file in your repository, then you can add
 this library with the following line:
 
 ```txt
-spimdisasm>=1.36.1,<2.0.0
+spimdisasm>=1.37.0,<2.0.0
 ```
 
 ### Development version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.36.2"
+version = "1.37.0-dev0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.36.1"
+version = "1.36.2"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "spimdisasm"
 # Version should be synced with spimdisasm/__init__.py
-version = "1.37.0-dev0"
+version = "1.37.0"
 description = "MIPS disassembler"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-rabbitizer>=1.12.5,<2.0.0
+rabbitizer>=1.14.0,<2.0.0

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 __version_info__: tuple[int, int, int] = (1, 37, 0)
-__version__ = ".".join(map(str, __version_info__)) + "-dev0"
+__version__ = ".".join(map(str, __version_info__)) # + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 36, 2)
+__version_info__: tuple[int, int, int] = (1, 37, 0)
 __version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 

--- a/spimdisasm/__init__.py
+++ b/spimdisasm/__init__.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-__version_info__: tuple[int, int, int] = (1, 36, 1)
-__version__ = ".".join(map(str, __version_info__)) # + "-dev0"
+__version_info__: tuple[int, int, int] = (1, 36, 2)
+__version__ = ".".join(map(str, __version_info__)) + "-dev0"
 __author__ = "Decompollaborate"
 
 from . import common as common

--- a/spimdisasm/common/Utils.py
+++ b/spimdisasm/common/Utils.py
@@ -254,6 +254,7 @@ bannedEscapeCharacters = {
     0x1D,
     0x1E,
     0x1F,
+    0x7F,
 }
 
 escapeCharactersSpecialCases = {

--- a/spimdisasm/common/__init__.py
+++ b/spimdisasm/common/__init__.py
@@ -23,7 +23,7 @@ from .Context import Context as Context
 from .FileSplitFormat import FileSplitFormat as FileSplitFormat
 from .FileSplitFormat import FileSplitEntry as FileSplitEntry
 from .ElementBase import ElementBase as ElementBase
-from .GpAccesses import GlobalOffsetTable as GlobalOffsetTable
+from .GpAccesses import GotEntry as GotEntry
 from .OrderedEnum import OrderedEnum as OrderedEnum
 from .Relocation import RelocType as RelocType
 from .Relocation import RelocationInfo as RelocationInfo

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -127,7 +127,7 @@ class Elf32File:
 
         if Elf32HeaderFlag.ABI2 in self.elfFlags and Elf32HeaderFlag.O64 in self.elfFlags:
             common.Utils.eprint("Warning: Elf compiled using N64 ABI. Support is in experimental state")
-            common.GlobalConfig.ABI = common.Abi.N32
+            common.GlobalConfig.ABI = common.Abi.N64
         elif Elf32HeaderFlag.ABI2 in self.elfFlags:
             common.Utils.eprint("Warning: Elf compiled using N32 ABI. Support is in experimental state")
             common.GlobalConfig.ABI = common.Abi.N32

--- a/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
+++ b/spimdisasm/elfObjDisasm/ElfObjDisasmInternals.py
@@ -373,10 +373,12 @@ def processGlobalOffsetTable(context: common.Context, elfFile: elf32.Elf32File) 
         common.GlobalConfig.GP_VALUE = elfFile.reginfo.gpValue
 
     if elfFile.dynamic is not None and elfFile.got is not None:
-        globalsTable = [gotEntry.getAddress() for gotEntry in elfFile.got.globalsTable]
+        localsTable = [common.GotEntry(address, False) for address in elfFile.got.localsTable]
+        globalsTable = [common.GotEntry(gotEntry.getAddress(), True) for gotEntry in elfFile.got.globalsTable]
+        tableEntries = localsTable + globalsTable
 
         assert elfFile.dynamic.pltGot is not None
-        context.initGotTable(elfFile.dynamic.pltGot, elfFile.got.localsTable, globalsTable)
+        context.setupGotTable(elfFile.dynamic.pltGot, tableEntries)
 
         for small in elfFile.smallSections.values():
             context.addSmallSection(small.addr, small.size)

--- a/spimdisasm/mips/sections/MipsSectionBase.py
+++ b/spimdisasm/mips/sections/MipsSectionBase.py
@@ -208,6 +208,9 @@ class SectionBase(FileBase):
                 pass
             else:
                 return False
+        elif w % 4 == 0 and self.containsVram(w) and w != contextSym.vram:
+            # Likely to be a pointer to a symbol in the current section.
+            return False
 
         currentVram = self.getVramOffset(localOffset)
         currentVrom = self.getVromOffset(localOffset)

--- a/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
+++ b/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
@@ -95,10 +95,20 @@ def getSplits(fileSplitsPath: Path|None, vromStart: int, vromEnd: int, fileVram:
 
         endVram = fileVram + vromEnd - vromStart
 
-        splitEntry = common.FileSplitEntry(vromStart, fileVram, "", common.FileSectionType.Text, vromEnd, False, disasmRsp)
-        splits.append(splitEntry)
+        if vromStart < vromEnd:
+            splitEntry = common.FileSplitEntry(vromStart, fileVram, "", common.FileSectionType.Text, vromEnd, False, disasmRsp)
+            splits.append(splitEntry)
+        elif vromStart == vromEnd:
+            # Empty .text section. We can allow it if the user wants to only disassemble data for some reason.
+            if vromDataStart is None or vromDataEnd is None:
+                common.Utils.panic("Error: The given start and end addresses are the same, and no data addresses were given either.")
+        else: # vromStart > vromEnd
+            common.Utils.panic(f"Error: The given start address (0x{vromStart:X}) is larger than the end address (0x{vromEnd:X}).")
 
         if vromDataStart is not None and vromDataEnd is not None:
+            if vromDataStart >= vromDataEnd:
+                common.Utils.panic(f"Error: The end address of data (0x{vromDataEnd:X}) must be larger than its start address (0x{vromDataStart:X}).")
+
             dataVramStart = endVram
             endVram = dataVramStart + vromDataEnd - vromDataStart
             vromEnd = vromDataEnd


### PR DESCRIPTION
## [1.37.0] - 2025-09-18

### Added

- `Context.setupGotTable()`: Allows finer control over the GOT table.
  - The user can manually define which entries are got-local and which ones are
    got-global, instead of relying on a given order.
  - Useful for programs that don't follow the ABI way of defining the GOT; first
    the locals entries and then the globals entries.
- `common.GotEntry` class: Defines if an entry of the GOT is either local or
  global. It must be used together with `Context.setupGotTable()`

### Changed

- `SingleFileDisasm`:
  - Error out if the start address is larger than the end address of `.text` or
    data.
  - Avoid writing a `.text.s` file if the `.text` start and end addresses are
    the same, as long as the user has given data addresses, otherwise panic.

### Deprecated

- `Context.initGotTable()`: Prefer `Context.setupGotTable()` instead.

### Fixed

- Avoid guessing symbols as string if the first word of the symbol is an address
  to a known symbol.
- `rabbitizer` 1.14.0 or above is required.
  - Adds a new argument to the R3000GTE `dpct` instruction that exposes required
    garbage bits.
