### PR TITLE
Add use_non_matching_label option

### DIFF
--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -264,6 +264,8 @@ class ContextSymbol:
     given value.
     """
 
+    useNonMatchingLabel: bool = True
+
     @property
     def vram(self) -> int:
         return self.address

--- a/spimdisasm/common/SymbolsSegment.py
+++ b/spimdisasm/common/SymbolsSegment.py
@@ -627,3 +627,7 @@ class SymbolsSegment:
                 align = pairs.get("align")
                 if align is not None:
                     contextSym.setAlignment(int(align, 0))
+
+                useNonMatchingLabel = Utils.getMaybeBooleyFromMaybeStr(pairs.get("use_non_matching_label"))
+                if useNonMatchingLabel is not None:
+                    contextSym.useNonMatchingLabel = useNonMatchingLabel

--- a/spimdisasm/mips/symbols/MipsSymbolBase.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBase.py
@@ -154,7 +154,7 @@ class SymbolBase(common.ElementBase):
         return ""
 
     def getNonMatchingLabel(self, symName: str, symSize: int|None) -> str:
-        if common.GlobalConfig.ASM_NM_LABEL:
+        if common.GlobalConfig.ASM_NM_LABEL and self.contextSym.useNonMatchingLabel:
             out = f"{common.GlobalConfig.ASM_NM_LABEL} {symName}"
             if symSize is not None:
                 if symSize < 1:


### PR DESCRIPTION
This adds the option to decide which symbols have the nonmatching macro label. This defaults to true, effectively meaning that adding `use_non_matching_label:False` will remove the nonmatching label section.

My personal use case for this is that I would like to keep my handwritten asm auto-extracted but this will lower the progress tracked by mapfile_parser due to the nonmatching label that gets added.