### PR TITLE
set `bigAddendWorkaroundForMigratedFunctions` to `False` for MWCCPS2

### DIFF
--- a/spimdisasm/common/CompilerConfig.py
+++ b/spimdisasm/common/CompilerConfig.py
@@ -90,7 +90,7 @@ class Compiler(enum.Enum):
     PSYQ = CompilerProperties("PSYQ", prevAlign_double=3, prevAlign_jumptable=3, allowRdataMigration=True)
 
     # PS2
-    MWCCPS2 = CompilerProperties("MWCCPS2", prevAlign_jumptable=4)
+    MWCCPS2 = CompilerProperties("MWCCPS2", prevAlign_jumptable=4, bigAddendWorkaroundForMigratedFunctions=False)
     EEGCC = CompilerProperties("EEGCC", prevAlign_jumptable=3, prevAlign_string=3, prevAlign_function=3)
 
     @staticmethod


### PR DESCRIPTION
per @Mc-muffin's suggestion, since MWCCPS2 doesn't use an assembler, should we turn off this assembler-related flag?

i've had this flag off in my local copy of spimdisasm for a few months, i don't remember why i turned it off originally but i think things are okay without it, and only today this showed up again as an issue somewhere (i spent on a few hours on issues related to #202, oof :'))
