### PR TITLE
Quote symbol names containing whitespace

### DIFF
--- a/spimdisasm/common/ContextSymbols.py
+++ b/spimdisasm/common/ContextSymbols.py
@@ -584,7 +584,7 @@ class ContextSymbol:
 
     def getName(self) -> str:
         name = self.getNameUnquoted()
-        if "@" in name or "<" in name or "\\" in name or "-" in name or "+" in name:
+        if "@" in name or "<" in name or "\\" in name or "-" in name or "+" in name or any(c.isspace() for c in name):
             return f'"{name}"'
         return name
 


### PR DESCRIPTION
## Summary

- Quote symbol names containing whitespace when emitting asm labels.
- Fixes ELF symbols with spaces being split into multiple macro arguments, such as padded MWCC static-init symbols.

Thanks to @dreamingmoths and @Mc-muffin for the help.


## Context

MWCC can emit padded static-init symbols with embedded spaces, for example:

```text
.p__sinit_hk3AxisSweep.cpp                                                                            .p__sinit_hk = 0x006B5324; // size:4 visibility:local allow_duplicated:true
```

This symbol name is present in the original ELF:

```text
006b5324 t .p__sinit_hk3AxisSweep.cpp                                                                            .p__sinit_hk
```

Currently, Spimdisasm emits it without quotes:

```asm
dlabel .p__sinit_hk3AxisSweep.cpp                                                                            .p__sinit_hk, local
```

GNU AS then reads this as multiple macro arguments and errors. The label needs to be emitted quoted:

```asm
dlabel ".p__sinit_hk3AxisSweep.cpp                                                                            .p__sinit_hk", local
```

This appears related to the MWCC static initializer symbol padding bug documented here:
https://decomp.wiki/compilers/MWCC#known-bugs


## Testing

- Verified padded MWCC static-init symbols with embedded spaces emit as quoted labels.