### PR TITLE
Add option to disable BSS pad symbols

### DIFF
--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -296,6 +296,8 @@ class GlobalConfigType:
     """Create dummy and unreferenced rodata symbols after another symbol which has non-zero user-declared size.
 
     The generated pad symbols may have non-zero data"""
+    CREATE_BSS_PADS: bool = True
+    """Create dummy and unreferenced bss/sbss symbols after another symbol which has non-zero user-declared size."""
 
     QUIET: bool = False
     VERBOSE: bool = False
@@ -433,6 +435,7 @@ Defaults to {self.ASM_GLOBALIZE_TEXT_LABELS_REFERENCED_BY_NON_JUMPTABLE}""", act
 
         miscConfig.add_argument("--create-data-pads", help=f"Create dummy and unreferenced data symbols after another symbol which has non-zero user-declared size.\nThe generated pad symbols may have non-zero data. Defaults to {self.CREATE_DATA_PADS}", action=Utils.BooleanOptionalAction)
         miscConfig.add_argument("--create-rodata-pads", help=f"Create dummy and unreferenced rodata symbols after another symbol which has non-zero user-declared size.\nThe generated pad symbols may have non-zero data. Defaults to {self.CREATE_RODATA_PADS}", action=Utils.BooleanOptionalAction)
+        miscConfig.add_argument("--create-bss-pads", help=f"Create dummy and unreferenced bss/sbss symbols after another symbol which has non-zero user-declared size. Defaults to {self.CREATE_BSS_PADS}", action=Utils.BooleanOptionalAction)
 
 
         verbosityConfig = parser.add_argument_group("Verbosity options")
@@ -653,6 +656,8 @@ Defaults to {self.ASM_GLOBALIZE_TEXT_LABELS_REFERENCED_BY_NON_JUMPTABLE}""", act
             self.CREATE_DATA_PADS = args.create_data_pads
         if args.create_rodata_pads is not None:
             self.CREATE_RODATA_PADS = args.create_rodata_pads
+        if args.create_bss_pads is not None:
+            self.CREATE_BSS_PADS = args.create_bss_pads
 
 
         if args.verbose is not None:

--- a/spimdisasm/mips/sections/MipsSectionBss.py
+++ b/spimdisasm/mips/sections/MipsSectionBss.py
@@ -58,15 +58,18 @@ class SectionBss(SectionBase):
             assert symbolVram < self.bssVramEnd
             bssSymbolOffsets.add(symbolVram - self.bssVramStart)
 
-            # If the bss has an explicit size then produce an extra symbol after it, so the generated bss symbol uses the user-declared size
-            if contextSym.hasUserDeclaredSize():
-                newSymbolVram = symbolVram + contextSym.getSize()
-                if newSymbolVram != self.bssVramEnd:
-                    assert newSymbolVram >= self.bssVramStart
-                    assert newSymbolVram < self.bssVramEnd, f"{self.name}, symbolVram={symbolVram:08X}, newSymbolVram={newSymbolVram:08X}, self.bssVramEnd={self.bssVramEnd:08X}"
-                    symOffset = symbolVram + contextSym.getSize() - self.bssVramStart
-                    bssSymbolOffsets.add(symOffset)
-                    autoCreatedPads.add(symOffset)
+            # If the bss/sbss has an explicit non-zero size then produce an extra symbol after it,
+            # so the generated symbol uses the user-declared size
+            if common.GlobalConfig.CREATE_BSS_PADS and contextSym.hasUserDeclaredSize():
+                contextSymSize = contextSym.getSize()
+                if contextSymSize > 0:
+                    newSymbolVram = symbolVram + contextSymSize
+                    if newSymbolVram != self.bssVramEnd:
+                        assert newSymbolVram >= self.bssVramStart
+                        assert newSymbolVram < self.bssVramEnd, f"{self.name}, symbolVram={symbolVram:08X}, newSymbolVram={newSymbolVram:08X}, self.bssVramEnd={self.bssVramEnd:08X}"
+                        symOffset = symbolVram + contextSymSize - self.bssVramStart
+                        bssSymbolOffsets.add(symOffset)
+                        autoCreatedPads.add(symOffset)
 
 
         sortedOffsets = sorted(bssSymbolOffsets)

--- a/spimdisasm/mips/symbols/MipsSymbolBss.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBss.py
@@ -64,10 +64,28 @@ Range check triggered: .bss symbol (name: {self.getName()}, address: 0x{self.con
         output += self.getPrevAlignDirective(0)
 
         symName = self.getName()
-        output += self.getNonMatchingLabel(symName, self.spaceSize)
+        symSize: int | None = None
+        if not common.GlobalConfig.CREATE_BSS_PADS:
+            symSize = self.contextSym.userDeclaredSize
+            if symSize is not None:
+                if symSize <= 0 or symSize > self.spaceSize:
+                    symSize = None
+
+        spaceSize = self.spaceSize
+        if symSize is not None:
+            spaceSize = symSize
+
+        output += self.getNonMatchingLabel(symName, spaceSize)
         output += self.getSymbolAsmDeclaration(symName, useGlobalLabel)
         output += self.generateAsmLineComment(0, emitRomOffset=False)
-        output += f" .space 0x{self.spaceSize:02X}{common.GlobalConfig.LINE_ENDS}"
+        output += f" .space 0x{spaceSize:02X}{common.GlobalConfig.LINE_ENDS}"
+
+        if symSize is not None:
+            output += self._getSymEnd(symName)
+
+        if spaceSize != self.spaceSize:
+            output += self.generateAsmLineComment(spaceSize, emitRomOffset=False)
+            output += f" .space 0x{self.spaceSize - spaceSize:02X}{common.GlobalConfig.LINE_ENDS}"
 
         nameEnd = self.getNameEnd()
         if nameEnd is not None:

--- a/spimdisasm/mips/symbols/MipsSymbolBss.py
+++ b/spimdisasm/mips/symbols/MipsSymbolBss.py
@@ -46,7 +46,10 @@ class SymbolBss(SymbolBase):
         if self.contextSym.hasUserDeclaredSize():
             # Check user declared size matches the size that will be generated
             contextSymSize = self.contextSym.getSize()
-            if self.spaceSize != contextSymSize:
+            sizeMismatch = self.spaceSize < contextSymSize
+            if common.GlobalConfig.CREATE_BSS_PADS:
+                sizeMismatch = self.spaceSize != contextSymSize
+            if sizeMismatch:
                 warningMessage = f"""
 Range check triggered: .bss symbol (name: {self.getName()}, address: 0x{self.contextSym.vram:08X}):
     User declared size (0x{contextSymSize:X}) does not match the .space that will be emitted (0x{self.spaceSize:X}).


### PR DESCRIPTION
## Summary

- Add a `--create-bss-pads` / `--no-create-bss-pads` option to control autogenerated BSS/SBSS pad symbols.
- Keep the default enabled to preserve existing output.
- Avoid BSS range-check warnings when pad symbols are disabled and a declared symbol intentionally absorbs following padding.

Thanks to @dreamingmoths and @Mc-muffin for the help.


## Context

Spimdisasm already has options for controlling autogenerated data and rodata pad symbols:

```text
--create-data-pads / --no-create-data-pads
--create-rodata-pads / --no-create-rodata-pads
```

BSS currently always creates pad symbols after user-sized symbols. For example, a BSS symbol with declared size `0x4` followed by another symbol at `+0x8` emits an autogenerated pad label for the gap:

```asm
dlabel some_bss_symbol
 .space 0x04

/* Automatically generated and unreferenced pad */
dlabel D_XXXXXXXX
 .space 0x04
```

This creates extra generated labels in BSS/SBSS output and can make objdiff views noisier.

Before:

<img width="1891" height="468" alt="image" src="https://github.com/user-attachments/assets/9be63958-4e25-41b4-b462-c68b32584581" />

After:

<img width="1894" height="331" alt="image" src="https://github.com/user-attachments/assets/5a3d3469-80da-4732-95c8-a06c4fbbc20c" /><br>


When those gap labels are not useful, disabling BSS pad creation folds the gap into the preceding BSS symbol instead:

```asm
dlabel some_bss_symbol
 .space 0x08
```

This PR adds the same style of control for BSS/SBSS via `CREATE_BSS_PADS`, exposed through the CLI as:

```text
--create-bss-pads
--no-create-bss-pads
```

When enabled, behavior stays unchanged. When disabled, Spimdisasm stops creating those autogenerated BSS/SBSS pad symbols.

## Notes

- This should be merged before the companion Splat PR that exposes `create_bss_pads`.
- Companion Splat PR: https://github.com/ethteck/splat/pull/540

## Testing

- Verified `--no-create-bss-pads` disables autogenerated BSS pad symbols.
- Verified `--create-bss-pads` preserves the existing autogenerated pad behavior.
- Verified zero-sized declared BSS symbols do not create pad symbols, matching data/rodata pad behavior.