### PR TITLE
add option to toggle MIPS gp_rel analyzer

### DIFF
--- a/spimdisasm/common/GlobalConfig.py
+++ b/spimdisasm/common/GlobalConfig.py
@@ -315,6 +315,8 @@ class GlobalConfigType:
     """Ignores words that starts in 0xXX"""
     WRITE_BINARY: bool = False
     """write to files splitted binaries"""
+    ANALYZE_GP_REL: bool = True
+    """controls the usage of the gp_rel analyzer for MIPS"""
 
 
     def addParametersToArgParse(self, parser: argparse.ArgumentParser) -> None:

--- a/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
+++ b/spimdisasm/mips/symbols/analysis/InstrAnalyzer.py
@@ -381,7 +381,7 @@ class InstrAnalyzer:
 
         upperHalf: int|None = pairingInfo.value
         luiOffset = pairingInfo.instrOffset
-        if pairingInfo.isGpRel:
+        if pairingInfo.isGpRel and common.GlobalConfig.ANALYZE_GP_REL:
             upperHalf = None
             luiOffset = None
 

--- a/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
+++ b/spimdisasm/singleFileDisasm/SingleFileDisasmInternals.py
@@ -51,6 +51,8 @@ def addOptionsToParser(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
 
     parser.add_argument("--function-info", help="Specifies a path where to output a csvs sumary file of every analyzed function", metavar="PATH")
 
+    parser.add_argument("--analyze-gp-rel", help=f"Activates the gp instruction analyzer for MIPS. Defaults to true",
+                          action=common.Utils.BooleanOptionalAction, default=True)
 
     common.Context.addParametersToArgParse(parser)
 
@@ -71,6 +73,7 @@ def applyArgs(args: argparse.Namespace) -> None:
 
     common.GlobalConfig.REMOVE_POINTERS = args.nuke_pointers
     common.GlobalConfig.IGNORE_BRANCHES = args.nuke_pointers
+    common.GlobalConfig.ANALYZE_GP_REL = args.analyze_gp_rel
     if args.nuke_pointers:
         common.GlobalConfig.IGNORE_WORD_LIST.add(0x80)
         if args.ignore_words:


### PR DESCRIPTION
### Summary

* Adds an `--analyze-gp-rel`/`--no-analyze-gp-rel` option to spimdisasm
* Default value is true. Previous behavior is not changed when not specified
* See reasoning and discussion in Discord here: https://discord.com/channels/897066363951128586/1224198647097593876/1489722831569944707

### Context

BlastCorps contains some assembly files which misuse $gp for accessing struct data. This triggers the gp analyzer of spimdisasm and replaces this access pattern with %gp_rel macros. When trying to compile this, the build errors with:

```
build/asm/hd_code/69BB0.s.o: in function `func_hd_code_802AE370':
(.text+0x90): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7B2'
(.text+0x94): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7B4'
(.text+0x9c): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7B6'
(.text+0xa4): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7B8'
(.text+0xa8): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7BA'
(.text+0xb0): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7BC'
(.text+0xb8): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7BE'
(.text+0xbc): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7C0'
(.text+0xc4): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7C2'
(.text+0xcc): relocation truncated to fit: R_MIPS_GPREL16 against `D_803ED7C4'
```

### Testing

* Run spimdisasm with and without the flag. Resulting diff:
```
//...
1111c1126
<     /* 000E68 00000E68 93960098 */  lbu         $s6, 0x98($gp)
---
>     /* 000E68 00000E68 93960098 */  lbu         $s6, %gp_rel(D_00000098)($gp)
1115c1130
<     /* 000E78 00000E78 93960050 */  lbu         $s6, 0x50($gp)
---
>     /* 000E78 00000E78 93960050 */  lbu         $s6, %gp_rel(D_00000050)($gp)
1119c1134
<     /* 000E88 00000E88 9396009B */  lbu         $s6, 0x9B($gp)
---
>     /* 000E88 00000E88 9396009B */  lbu         $s6, %gp_rel(D_0000009B)($gp)
1122c1137
<     /* 000E94 00000E94 8F85001C */  lw          $a1, 0x1C($gp)
---
>     /* 000E94 00000E94 8F85001C */  lw          $a1, %gp_rel(D_0000001C)($gp)
1136c1151
<     /* 000ECC 00000ECC 9788004E */  lhu         $t0, 0x4E($gp)
---
>     /* 000ECC 00000ECC 9788004E */  lhu         $t0, %gp_rel(D_0000004E)($gp)
1186c1201
<     /* 000F78 00000F78 27BDFFF8 */  addiu       $sp, $sp, -0x8
---
>     /* 000F78 00000F78 27BDFFF8 */  addiu       $sp, $sp, %lo(D_0000004C)
1209c1224
<     /* 000FCC 00000FCC 978A004C */  lhu         $t2, 0x4C($gp)
---
>     /* 000FCC 00000FCC 978A004C */  lhu         $t2, %gp_rel(D_0000004C)($gp)
1273c1288
<     /* 0010B0 000010B0 938E0096 */  lbu         $t6, 0x96($gp)
---
>     /* 0010B0 000010B0 938E0096 */  lbu         $t6, %gp_rel(D_00000096)($gp)
// ...
```
