### PR TITLE
Improve PSP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `SNC` compiler option
+- Add PSP related ELF constants
+- Add ELF program header parsing
+
 ## [1.42.4] - 2026-08-06
 
 ### Fixed

--- a/spimdisasm/common/CompilerConfig.py
+++ b/spimdisasm/common/CompilerConfig.py
@@ -93,6 +93,9 @@ class Compiler(enum.Enum):
     MWCCPS2 = CompilerProperties("MWCCPS2", prevAlign_jumptable=4, bigAddendWorkaroundForMigratedFunctions=False)
     EEGCC = CompilerProperties("EEGCC", prevAlign_jumptable=3, prevAlign_string=3, prevAlign_function=3)
 
+    # PSP
+    SNC = CompilerProperties("SNC", prevAlign_double=3, prevAlign_jumptable=3, allowRdataMigration=True, bigAddendWorkaroundForMigratedFunctions=False)
+
     @staticmethod
     def fromStr(value: str) -> Compiler|None:
         return compilerOptions.get(value)
@@ -109,5 +112,6 @@ compilerOptions: dict[str, Compiler] = {
         Compiler.PSYQ,
         Compiler.MWCCPS2,
         Compiler.EEGCC,
+        Compiler.SNC,
     ]
 }

--- a/spimdisasm/elf32/Elf32Constants.py
+++ b/spimdisasm/elf32/Elf32Constants.py
@@ -59,6 +59,9 @@ class Elf32ObjectFileType(enum.Enum):
     # LOPROC      0xff00        # Processor-specific range start
     # HIPROC      0xffff        # Processor-specific range end
 
+    SCE_PSPRELEXEC  = 0xFFA0
+    SCE_PSPOVERLAY  = 0xFFA8
+
 
 # Legal values for e_flags field of Elf32_Ehdr
 class Elf32HeaderFlag(enum.Enum):
@@ -236,6 +239,8 @@ class Elf32SectionHeaderType(enum.Enum):
     MIPS_OPTIONS    = 0x7000000D
     MIPS_SYMBOL_LIB = 0x70000020
     MIPS_ABIFLAGS   = 0x7000002A
+
+    SCE_SEGREL      = 0x700000A0
 
     @staticmethod
     def fromValue(value: int) -> Elf32SectionHeaderType|None:

--- a/spimdisasm/elf32/Elf32File.py
+++ b/spimdisasm/elf32/Elf32File.py
@@ -15,6 +15,7 @@ from .Elf32GlobalOffsetTable import Elf32GlobalOffsetTable
 from .Elf32Header import Elf32Header
 from .Elf32RegInfo import Elf32RegInfo
 from .Elf32SectionHeaders import Elf32SectionHeaders, Elf32SectionHeaderEntry
+from .Elf32ProgramHeaders import Elf32ProgramHeaders
 from .Elf32StringTable import Elf32StringTable
 from .Elf32Syms import Elf32Syms
 from .Elf32Rels import Elf32Rels
@@ -68,6 +69,7 @@ class Elf32File:
         self.reginfo: Elf32RegInfo | None = None
 
         self.sectionHeaders = Elf32SectionHeaders(array_of_bytes, self.header.shoff, self.header.shnum)
+        self.programHeaders = Elf32ProgramHeaders(array_of_bytes, self.header.phoff, self.header.phnum)
 
         shstrtabSectionEntry = self.sectionHeaders.sections[self.header.shstrndx]
         self.shstrtab = Elf32StringTable(array_of_bytes, shstrtabSectionEntry.offset, shstrtabSectionEntry.size)

--- a/spimdisasm/elf32/Elf32ProgramHeaders.py
+++ b/spimdisasm/elf32/Elf32ProgramHeaders.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2022-2024 Decompollaborate
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import dataclasses
+import struct
+from typing import Generator
+
+from .. import common
+
+
+# a.k.a. Phdr (program header)
+@dataclasses.dataclass
+class Elf32ProgramHeaderEntry:
+    type:       int  # word     # 0x00
+    offset:     int  # offset   # 0x04
+    vaddr:      int  # address  # 0x08
+    paddr:      int  # address  # 0x0C
+    filesz:     int  # word     # 0x10
+    memsz:      int  # word     # 0x14
+    flags:      int  # word     # 0x18
+    align:      int  # word     # 0x1C
+                                # 0x20
+
+    @staticmethod
+    def fromBytearray(array_of_bytes: bytes, offset: int = 0) -> Elf32ProgramHeaderEntry:
+        headerFormat = common.GlobalConfig.ENDIAN.toFormatString() + "8I"
+        unpacked = struct.unpack_from(headerFormat, array_of_bytes, offset)
+
+        return Elf32ProgramHeaderEntry(*unpacked)
+
+
+class Elf32ProgramHeaders:
+    def __init__(self, array_of_bytes: bytes, phoff: int, phnum: int) -> None:
+        self.headers: list[Elf32ProgramHeaderEntry] = list()
+        self.phoff: int = phoff
+        self.phnum: int = phnum
+
+        for i in range(phnum):
+            programHeaderEntry = Elf32ProgramHeaderEntry.fromBytearray(array_of_bytes, phoff + i * 0x20)
+            self.headers.append(programHeaderEntry)
+
+    def __iter__(self) -> Generator[Elf32ProgramHeaderEntry, None, None]:
+        for entry in self.headers:
+            yield entry
+
+    def __len__(self) -> int:
+        return len(self.headers)


### PR DESCRIPTION
Improve PSP support (and some other nice-to-haves) by adding a few things:
- SNC compiler option
- ELF constants used in PSP executables
- ELF program header parsing